### PR TITLE
Fix various test errors

### DIFF
--- a/test-config.json
+++ b/test-config.json
@@ -8,6 +8,5 @@
   "noSigUserId": "538241a0-16f1-42b6-bf54-48aef23da8c4",
   "password": "qweqweasd",
   "templateId": "cf2a46c2-8d6e-4258-9d62-752547b1a419",
-  "envelopeId": "e5266e64-d7a3-4467-9fe0-31cfa18474ca",
   "templateRole": "bob"
 }

--- a/test/component-tests/envelopes.spec.js
+++ b/test/component-tests/envelopes.spec.js
@@ -8,7 +8,7 @@ const docusign = require('../../docusign');
 const dsUtils = require('../../dsUtils');
 
 let client = null;
-let envelopeId = config.envelopeId;
+let envelopeId;
 let templateId = config.templateId;
 let fullName = 'DocuSign NPM';
 let email = config.email;
@@ -56,6 +56,17 @@ test.before(function envelopesBefore (t) {
   })
   .then(_client => {
     client = _client;
+    return client;
+  })
+  .then(client => {
+    return client.envelopes.sendEnvelope(recipients, emailSubject, files, additionalParams)
+    .then(response => {
+      t.ok(response.envelopeId);
+      envelopeId = response.envelopeId;
+      t.ok(response.uri);
+      t.ok(response.status === 'sent');
+      t.pass('Send envelope success');
+    });
   });
 });
 
@@ -185,15 +196,6 @@ test(function getTemplateView (t) {
     var regex = new RegExp('https://demo.docusign.net/Member/StartInSession.aspx?');
     t.ok(response.url);
     t.ok(regex.test(response.url));
-  });
-});
-
-test(function sendEnvelope (t) {
-  return client.envelopes.sendEnvelope(recipients, emailSubject, files, additionalParams)
-  .then(response => {
-    t.ok(response.envelopeId);
-    t.ok(response.uri);
-    t.ok(response.status === 'sent');
   });
 });
 

--- a/test/component-tests/envelopes.spec.js
+++ b/test/component-tests/envelopes.spec.js
@@ -121,7 +121,7 @@ test(function getEnvelopeList (t) {
     date.setMonth(date.getMonth() - 1);
   } else {
     date.setMonth(12);
-    date.setYear(date.getYear() - 1);
+    date.setYear(date.getFullYear() - 1);
   }
   return client.envelopes.getEnvelopeList(date)
   .then(response => {

--- a/test/component-tests/folders.spec.js
+++ b/test/component-tests/folders.spec.js
@@ -30,7 +30,7 @@ test(function getEnvelopes (t) {
 });
 
 test(function searchThroughEnvelopes (t) {
-  return client.folders.searchThroughEnvelopes('please')
+  return client.folders.searchThroughEnvelopes('DocuSign')
   .then(response => {
     t.ok(response.folderItems.length > 0);
     t.ok(response.totalSetSize);


### PR DESCRIPTION
These were mostly cause by stale account expectations. This has been fixed
by relying upon the data created by the tests themselves.