### PR TITLE
Upgrade request version to v2.74.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lodash.isempty": "4.0.0",
     "lodash.isplainobject": "4.0.0",
     "lodash.mergewith": "4.0.3",
-    "request": "2.67.0",
+    "request": "2.79.0",
     "temp": "0.8.3",
     "uuid": "2.0.1"
   },


### PR DESCRIPTION
Request v2.69.0 pulls in tough-cookie v2.2.0 which has a known vulnerability
https://nodesecurity.io/advisories/130

Request v2.74.0 upgrades tough-cookie to v2.3.0 in which the vulnerability is
addressed: https://github.com/request/request/commit/4f03ea8a8399ef17f1d5c71defd08184d9cbdae3

We happen to be using v7.1.1 of docusign module so I'd definitely very much appreciate if you could publish a patch version on 7.x with this fix as well :)