### PR TITLE
Fixed constants/checks

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -96,7 +96,7 @@
     if (basePath.includes('https://demo')) {
       return exports.prototype.OAuth.BasePath.DEMO;
     }
-    if (basePath.includes('https://docusign')) {
+    if (basePath.includes('https://www.docusign')) {
       return exports.prototype.OAuth.BasePath.PRODUCTION;
     }
   };

--- a/src/RestApi.js
+++ b/src/RestApi.js
@@ -1,4 +1,4 @@
-const PRODUCTION_BASE_PATH = 'https://docusign.net/restapi';
+const PRODUCTION_BASE_PATH = 'https://www.docusign.net/restapi';
 const DEMO_BASE_PATH = 'https://demo.docusign.net/restapi';
 const STAGE_BASE_PATH = 'https://stage.docusign.net/restapi';
 


### PR DESCRIPTION
docusign.net certificate is invalid.
www.docusign.net works fine.

Seems like default values at  
`var defaults = {
      basePath: 'https://www.docusign.net/restapi'.replace(/\/+$/, ''),
      oAuthBasePath: require('./OAuth').BasePath.PRODUCTION,
    };` 
were adjusted to point to **www.docusign.net** endpoint while other constants were not.