### PR TITLE
fix: OutOfMemory error while deserializing large PDFs, fixes #183

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -445,7 +445,7 @@
     // Rely on SuperAgent for parsing response body.
     // See http://visionmedia.github.io/superagent/#parsing-response-bodies
     var data = response.body || (response.res && response.res.data);
-    if (data == null || !Object.keys(data).length) {
+    if (returnType !== Object && (data == null || !Object.keys(data).length)) {
       // SuperAgent does not always produce a body; use the unparsed response as a fallback
       data = response.text;
     }


### PR DESCRIPTION
This PR fixes issue #183.

When the Docusign envelopes API returns a PDF (binary object), the `deserialize` function should not attempt to execute `Object.keys` on the binary response. In our case, `Object.keys` returns more than 15M entries and triggers an OOM. It is even more apparent if you are trying to generate a large PDF (~80 pages).

By using the `returnType` parameter, we are able to bypass the remaining conditions and the code works as expected. The `convertToType` is coded properly and return the raw `data` object.

Please consider this issue as a blocking issue. Happy to provide more explanations if needed.