### PR TITLE
Check if data is an object when deserializing

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -445,7 +445,7 @@
     // Rely on SuperAgent for parsing response body.
     // See http://visionmedia.github.io/superagent/#parsing-response-bodies
     var data = response.body || (response.res && response.res.data);
-    if (data == null || !Object.keys(data).length) {
+    if (data == null || (typeof data === 'object') && !Object.keys(data).length) {
       // SuperAgent does not always produce a body; use the unparsed response as a fallback
       data = response.text;
     }


### PR DESCRIPTION
We have an issue with the current implementation.
Sometime data is a huge string and Object.keys(data) throws an exception:

```
message: Too many properties to enumerate, 
name: RangeError, 
stack: 
RangeError: Too many properties to enumerate
    at Function.keys (<anonymous>)
    at exports.deserialize (/home/node/hlx-service-web/node_modules/docusign-esign/src/ApiClient.js:448:33)
    at /home/node/hlx-service-web/node_modules/docusign-esign/src/ApiClient.js:568:28
    at Shim.applySegment (/home/node/hlx-service-web/node_modules/newrelic/lib/shim/shim.js:1425:20)
    at wrappedCallback (/home/node/hlx-service-web/node_modules/newrelic/lib/shim/shim.js:1282:21)
    at Request.callback (/home/node/hlx-service-web/node_modules/superagent/lib/node/index.js:706:12)
    at Request.wrappedCallback [as callback] (/home/node/hlx-service-web/node_modules/@newrelic/superagent/lib/instrumentation.js:50:21)
```